### PR TITLE
soong: Forbidden pkg-config again

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -109,7 +109,6 @@ var Configuration = map[string]PathConfig{
 	"numfmt":      Allowed,
 	"openssl":     Allowed,
 	"patch":       Allowed,
-	"pkg-config":  Allowed,
 	"pstree":      Allowed,
 	"python3":     Allowed,
 	"python3.6":   Allowed,
@@ -140,6 +139,7 @@ var Configuration = map[string]PathConfig{
 	"ld":         Forbidden,
 	"ld.bfd":     Forbidden,
 	"ld.gold":    Forbidden,
+	"pkg-config": Forbidden,
 
 	// These are toybox tools that only work on Linux.
 	"pgrep": LinuxOnlyPrebuilt,


### PR DESCRIPTION
* Fixes kernel build failure in Arch Linux due to missing header file error even if it exists

Log:
fatal error: 'yaml.h' file not found
