### PR TITLE
check_boot_jars: Add xiaomi packages to the whitelist

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -315,5 +315,5 @@ org\.ifaa\.android\.manager.*
 com.camera.camera2.extensions.*
 
 ###################################################
-# Xiaomi Extensions
-com.xiaomi.extensions.*
+# Xiaomi adds
+com\.xiaomi\..*


### PR DESCRIPTION
Apparently this ones better🫪, and tbh **com.xiaomi.extensions.*** doesn't work when we build patched apk of newer Xiaomi IMS